### PR TITLE
[docs] 更新 README.md 以包含新技能 issue-tracker (Closes #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,19 @@ BloomSkill AI Kit 是一個專為現代 AI Agent（如 Antigravity, Cursor, Clau
 
 - **Slash Commands**:
   - `/git-manager`: 總入口，引導您完成標準開發交付流程。
-  - `/report-format`: 自動分析變更並生成精美的 PR 描述。
-  - `/sub-commit`: 互動式提交，自動檢查需求單號規範。
-- **特色**: 內建跨平台偵測指令，支援 `gh` 與 `tea` 雙平台。
+  - `/sub-commit`: AI 主動分析變更並提議提交訊息與 Stage 範圍。
+- **特色**: 整合 GitHub MCP Server 與 `gh` CLI，支援智能環境降級。
+
+---
+
+### 📋 [Issue Tracker](.agent/skills/issue-tracker/)
+
+**核心功能**: 負責 GitHub Issue 的建立、管理與開發任務分發，實現開發閉環。
+
+- **Slash Commands**:
+  - `/issue-tracker`: 主動偵測問題並引導建立 GitHub Issue 與任務盤點。
+  - `/sub-create-pr-linked`: 自動建立 PR 並關聯對應的 Issue (#ID)，實現自動化結案。
+- **特色**: 強化「Issue First」開發準則，確保所有變更有跡可循。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ BloomSkill AI Kit 是一個專為現代 AI Agent（如 Antigravity, Cursor, Clau
 
 ---
 
+### 🔨 [Skill Generator](.agent/skills/skill-generator/)
+
+**核心功能**: 用於快速產生、模板化與初始化新的 BloomSkill Agent 技能套件。
+
+- **Slash Commands**: `/ideate` → `/develop` → `/validate` → `/test` (PDCA 四階段)。
+- **特色**: 嚴格遵循模板規範，自動產出具備 PDCA 生命週期與安全防護的標準化技能。
+
+---
+
+### 🧪 [Skill Tester](.agent/skills/skill-tester/)
+
+**核心功能**: 讀取指定 Skill 的憲章與工作流，自動在沙盒中建立測試案例並驗證其行為。
+
+- **Slash Commands**: 調用後自動選擇目標 Skill 並開始 AC 驗證。
+- **特色**: **沙盒隔離 (Sanbox Isolation)** 原則，確保測試過程不污染原始項目。
+
+---
+
 ## 📦 如何使用 (Usage Guide)
 
 ### 方法 A：自動導出 (推薦)


### PR DESCRIPTION
### 📋 修正報告 (Issue #10)

本次更新完成了遺漏的 `README.md` 內容同步。

#### 🛠️ 修改清單
- 在「現有技能庫」中新增了 `issue-tracker` 的章節。
- 更新了 `git-manager` 的指令說明（反映最新的 AI 主動提議模式）。
- 整合了 MCP Server 相關的功能特色描述。

Closes #10